### PR TITLE
Use env -S in shebang

### DIFF
--- a/richify.py
+++ b/richify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env uv run
+#!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.8"
 # dependencies = [


### PR DESCRIPTION
In a shebang line using `env`, if you run a command with subcommands or options (in this case `uv run`), `env -S` or `--split-string` is required. Otherwise the command gets passed as a single token, and the script raises an error like:
```sh
/usr/bin/env: ‘uv run’: No such file or directory
```